### PR TITLE
Enable to run the program by sending the cookie and the URL as arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,5 @@ FROM python:2.7-slim
 RUN pip install requests
 COPY ./code /code
 WORKDIR /code
+RUN chmod +x from-arguments.py
+ENTRYPOINT ["python", "/code/from-arguments.py"]

--- a/code/from-arguments.py
+++ b/code/from-arguments.py
@@ -1,0 +1,15 @@
+import sys
+import re
+from downloader import Downloader
+
+cookie = sys.argv[1]
+dl = Downloader(cookie=cookie)
+
+if len(sys.argv) != 3:
+    raise Exception('Invalid arguments. Usage : {program} <cookie> <url_or_class_id>'.format(program=sys.argv[0]))
+
+if re.match("^[0-9]+$", sys.argv[2]) is not None:
+	dl.download_course_by_class_id(sys.argv[2])
+else:
+	dl.download_course_by_url(sys.argv[2])
+


### PR DESCRIPTION
This PR allows to download the videos by specifying the cookie content and the URL in the program arguments instead of editing `example.py` manually.

It also simplifies the use of the Docker image, allowing to run : 
`docker-compose run --rm ssdl <cookie> <URL>`
instead of editing `example.py` manually and then running:
`docker-compose run --rm ssdl python example.py`