### PR TITLE
Implemented cloudscraper as a workaround for 403 error during video fetch, fixes #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ from downloader import Downloader
 cookie = """
 ADD YOUR COOKIE HERE
 """
+
 4. Run the script and enter the number of courses you want to download. Then enter the URL of each of the courses.
 
     If you choose to download all classes in a public list (for example: https://www.skillshare.com/lists/Classes-for-Getting-Creative-Indoors/1347947), use the

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ from downloader import Downloader
 cookie = """
 ADD YOUR COOKIE HERE
 """
+```
 
 4. Run the script and enter the number of courses you want to download. Then enter the URL of each of the courses.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Skillshare video downloader in python
 
-I needed offline access to some skillshare courses I wanted to take while on vacation.
-Video download is only available in the skillshare mobile apps and I didn't want to
-choose between shaky 3G streaming or watching on a tiny mobile screen so I put together a
-quick and dirty video downloader in python.
-
 ### Support your content creators, do NOT use this for piracy!
 
 You will need a skillshare premium account to access premium content.
@@ -27,17 +22,12 @@ from downloader import Downloader
 cookie = """
 ADD YOUR COOKIE HERE
 """
+4. Run the script and enter the number of courses you want to download. Then enter the URL of each of the courses.
 
-dl = Downloader(cookie=cookie)
+    If you choose to download all classes in a public list (for example: https://www.skillshare.com/lists/Classes-for-Getting-Creative-Indoors/1347947), use the
+    download_list() function and enter the URL of the list.
 
-# download by class URL:
-dl.download_course_by_url('https://www.skillshare.com/classes/Art-Fundamentals-in-One-Hour/189505397')
-
-# or by class ID:
-# dl.download_course_by_class_id(189505397)
-```
-
-4. (Optionally) run with docker and docker-compose:
+5. (Optionally) run with docker and docker-compose:
 ```
 docker-compose build
 docker-compose run --rm ssdl python example.py

--- a/code/example.py
+++ b/code/example.py
@@ -1,4 +1,6 @@
 from downloader import Downloader
+from bs4 import BeautifulSoup as BS
+import urllib.request
 
 cookie = """
 ADD YOUR COOKIE HERE
@@ -6,8 +8,49 @@ ADD YOUR COOKIE HERE
 
 dl = Downloader(cookie=cookie)
 
-# download by class URL:
-dl.download_course_by_url('https://www.skillshare.com/classes/Art-Fundamentals-in-One-Hour/189505397')
 
-# or by class ID:
-# dl.download_course_by_class_id(189505397)
+def download_course():
+    # download individual class
+    # # download by class URL:
+    course_url = input("Enter class URL: ")
+    dl.download_course_by_url(course_url)
+
+    # # or by class ID:
+    # course_url = input("Enter class ID: ")
+    # # dl.download_course_by_class_id(input("Enter class ID"))
+
+# download classes in a public list
+
+
+def download_list():
+    hdr = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
+           'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+           'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+           'Accept-Encoding': 'none',
+           'Accept-Language': 'en-US,en;q=0.8',
+           'Connection': 'keep-alive'}
+
+    list_url = input("Enter list URL: ")
+    req = urllib.request.Request(list_url, headers=hdr)
+    html = urllib.request.urlopen(req)
+    soup = BS(html, features="html.parser")
+    elem = soup.findAll('div', {'class': 'list-item'})
+
+    for course in elem:
+        course_url = course.find('a').attrs['href'].split('?')[0]
+        dl.download_course_by_url(course_url)
+
+# download multiple courses
+
+
+def download_multiple_courses():
+    count = int(input("Number of courses to download: "))
+    course_list = []
+    for i in range(count):
+        course_list.append(input("Enter course URL: "))
+
+    for course_url in course_list:
+        dl.download_course_by_url(course_url)
+
+
+download_multiple_courses()


### PR DESCRIPTION
The requests for the video were getting denied by a 403 error due to Cloudflare. The regular requests were replaced with a [cloudscraper](https://github.com/venomous/cloudscraper) request to overcome the problem.