### PR TITLE
Implemented mahasatwas bug fix for #32, #issuecomment-660545525

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 data/*
+.idea
+code/data/*
+code/houdinii.py

--- a/code/downloader.py
+++ b/code/downloader.py
@@ -107,8 +107,9 @@ class Downloader(object):
             url='https://api.skillshare.com/classes/{}'.format(class_id),
             headers={
                 'Accept': 'application/vnd.skillshare.class+json;,version=0.8',
-                'User-Agent': 'Skillshare/4.1.1; Android 5.1.1',
+                'User-Agent': 'Skillshare/5.3.0; Android 9.0.1',
                 'Host': 'api.skillshare.com',
+                'Referer': 'https://www.skillshare.com/',
                 'cookie': self.cookie,
             }
         )


### PR DESCRIPTION
The requests for video meta data were getting denied due to faulty headers. Implemented the solution by mahasatwa ([Fixes #32](https://github.com/kallqvist/skillshare-downloader/issues/32#issuecomment-660545525)).  Note, this is my first ever pull request. Please let me know if I missed a step.